### PR TITLE
feat: workflow events

### DIFF
--- a/core/constants/topics.js
+++ b/core/constants/topics.js
@@ -33,7 +33,7 @@ exports.host = {
 
 exports.task = {
   crud: 'task-crud',
-  execution: 'task-execution', // create/start job
+  //execution: 'task-execution', // create/start job
   hold: 'task-hold-execution', // create holded task execution
   assigned: 'task-assigned', // assigned to agent
   result: 'task-result', // job result updated
@@ -46,9 +46,9 @@ exports.workflow = {
   //crud: 'workflow-crud',
   job: {
     crud: 'workflow-job-crud',
-    finished: 'workflow-job-finished'
+    finished: 'workflow-job-finished' // workflow job completed, no more tasks to execute
   },
-  execution: 'workflow-execution',
+  //execution: 'workflow-execution',
 }
 
 exports.job = {

--- a/core/entity/job/workflow.js
+++ b/core/entity/job/workflow.js
@@ -1,3 +1,4 @@
+const util = require('util');
 const BaseSchema = require('../base-schema')
 const Schema = require('mongoose').Schema;
 const ObjectId = Schema.Types.ObjectId;
@@ -61,4 +62,16 @@ const props = {
   active_jobs_counter: { type: Number, default: undefined }
 }
 
-module.exports = new BaseSchema(props, { collection: 'jobs' })
+//module.exports = new BaseSchema(props, { collection: 'jobs' })
+const WorkflowSchema = new BaseSchema(props, { collection: 'jobs' })
+WorkflowSchema.statics.incActiveJobs = async function (id, amount) {
+  return this.updateOne(
+    { _id: id },
+    {
+      $inc: {
+        active_jobs_counter: amount
+      }
+    }
+  )
+}
+module.exports = WorkflowSchema

--- a/core/entity/job/workflow.js
+++ b/core/entity/job/workflow.js
@@ -58,6 +58,7 @@ const props = {
   empty_viewers: { type: Boolean, default: false }, // if "true" acl will be empty on creation
   // @TODO REMOVE
   acl_dynamic: { type: Boolean, default: false },
+  active_jobs_counter: { type: Number, default: undefined }
 }
 
 module.exports = new BaseSchema(props, { collection: 'jobs' })

--- a/core/service/events/task-trigger-by.js
+++ b/core/service/events/task-trigger-by.js
@@ -20,10 +20,9 @@ module.exports = async function (payload) {
     // a task has completed its execution and triggered an event
     // or a monitor has changed its state
     if (
-      payload.topic === TopicConstants.task.execution ||
       payload.topic === TopicConstants.monitor.state ||
       payload.topic === TopicConstants.webhook.triggered ||
-      payload.topic === TopicConstants.workflow.execution
+      payload.topic === TopicConstants.job.finished
     ) {
       await triggeredByEvent(payload)
     }

--- a/core/service/events/workflow.js
+++ b/core/service/events/workflow.js
@@ -126,7 +126,7 @@ const executeWorkflowStep = async (
  * @return {Promise}
  *
  */
-const executeWorkflowStepVersion2 = (
+const executeWorkflowStepVersion2 = async (
   workflow,
   workflow_job,
   event,

--- a/core/service/events/workflow.js
+++ b/core/service/events/workflow.js
@@ -55,7 +55,11 @@ const handleWorkflowTaskJobEvent = async ({ event, data, job }) => {
     // reduce on job finished
     await App.Models.Job.Workflow.updateOne(
       { _id: workflow_job._id },
-      { $inc: { active_jobs_counter: -1 } }
+      {
+        $set: {
+          active_jobs_counter: workflow_job.active_jobs_counter
+        }
+      }
     )
 
     workflow_job.active_jobs_counter -= 1
@@ -173,7 +177,11 @@ const executeWorkflowStepVersion2 = async (
             workflow_job.active_jobs_counter += 1
             return App.Models.Job.Workflow.updateOne(
               { _id: workflow_job._id },
-              { $inc: { active_jobs_counter: 1 } }
+              {
+                $set: {
+                  active_jobs_counter: workflow_job.active_jobs_counter
+                }
+              }
             )
           }).catch(err => { return err })
 

--- a/core/service/events/workflow.js
+++ b/core/service/events/workflow.js
@@ -56,16 +56,8 @@ const handleWorkflowTaskJobFinishedEvent = async ({ event, data, job }) => {
 
   if (!isNaN(workflow_job.active_jobs_counter) && workflow_job.active_jobs_counter > 0) {
     workflow_job.active_jobs_counter -= 1
-
-    // reduce on job finished
-    await App.Models.Job.Workflow.updateOne(
-      { _id: workflow_job._id },
-      {
-        $set: {
-          active_jobs_counter: workflow_job.active_jobs_counter
-        }
-      }
-    )
+    // decrease on job finished
+    await App.Models.Job.Workflow.incActiveJobs(workflow_job._id, -1)
   } else {
     logger.warn('task-job finished within a workflow with 0 active jobs')
     logger.warn(workflow_job)
@@ -181,14 +173,7 @@ const executeWorkflowStepVersion2 = async (
 
             // increase
             workflow_job.active_jobs_counter += 1
-            return App.Models.Job.Workflow.updateOne(
-              { _id: workflow_job._id },
-              {
-                $set: {
-                  active_jobs_counter: workflow_job.active_jobs_counter
-                }
-              }
-            )
+            return App.Models.Job.Workflow.incActiveJobs(workflow_job._id, 1)
           }).catch(err => { return err })
 
         promises.push(jobPromise)

--- a/core/service/events/workflow.js
+++ b/core/service/events/workflow.js
@@ -4,7 +4,7 @@ const Workflow = require('../../entity/workflow').Workflow
 const Task = require('../../entity/task').Entity
 const TopicConstants = require('../../constants/topics')
 const JobConstants = require('../../constants/jobs')
-const createJob = require('./create-job')
+const createTaskJob = require('./create-job')
 const graphlib = require('graphlib')
 const ifTriggeredByJobSettings = require('./triggered-by-job-settings')
 
@@ -18,19 +18,16 @@ const ifTriggeredByJobSettings = require('./triggered-by-job-settings')
  */
 module.exports = async function (payload) {
   try {
-    if (payload.topic === TopicConstants.workflow.execution) {
+    if (payload.topic === TopicConstants.job.finished) {
       if (payload.job.workflow_job_id) {
-        // a task belonging to a workflow has finished
-        logger.log('This is a workflow event')
-        handleWorkflowEvent(payload)
+        // a task-job belonging to a workflow finished
+        logger.log('This is a workflow job event')
+        handleWorkflowTaskJobEvent(payload)
       }
-    }
-
-    if (
-      payload.topic === TopicConstants.task.execution ||
+    } else if (
       payload.topic === TopicConstants.monitor.state ||
       payload.topic === TopicConstants.webhook.triggered ||
-      payload.topic === TopicConstants.workflow.execution // a task inside a workflow can trigger tasks outside the workflow
+      payload.topic === TopicConstants.job.finished
     ) {
       // workflow trigger has occur
       triggerWorkflowByEvent(payload)
@@ -45,7 +42,7 @@ module.exports = async function (payload) {
  * @param {Job} job the job that generates the event
  * @param {Mixed} data event data, this is the job.output
  */
-const handleWorkflowEvent = async ({ event, data, job }) => {
+const handleWorkflowTaskJobEvent = async ({ event, data, job }) => {
   const { workflow_id, workflow_job_id } = job
   // search workflow step by generated event
   const workflow = await App.Models.Workflow.Workflow.findById(workflow_id)
@@ -53,6 +50,16 @@ const handleWorkflowEvent = async ({ event, data, job }) => {
 
   if (!workflow) { return }
   if (!workflow_job) { return }
+
+  if (!isNaN(workflow_job.active_jobs_counter)) {
+    // reduce on job finished
+    await App.Models.Job.Workflow.updateOne(
+      { _id: workflow_job._id },
+      { $inc: { active_jobs_counter: -1 } }
+    )
+
+    workflow_job.active_jobs_counter -= 1
+  }
 
   const executionFn = (
     workflow?.version === 2 ?
@@ -96,7 +103,7 @@ const executeWorkflowStep = async (
 
   const promises = []
   for (let i = 0; i < tasks.length; i++) {
-    const createPromise = createJob({
+    const createPromise = createTaskJob({
       order: workflow_job.order,
       user,
       task: tasks[i],
@@ -126,52 +133,68 @@ const executeWorkflowStepVersion2 = (
   argsValues,
   job
 ) => {
-
   if (!event) { return }
 
+  const promises = []
   const graph = new graphlib.json.read(workflow.graph)
   const nodeV = event.emitter_id.toString()
 
   const nodes = graph.successors(nodeV)
-  if (!nodes || (Array.isArray(nodes) && nodes.length === 0)) {
-    App.jobDispatcher.finishWorkflowJob(workflow_job, {
-      state: job.state,
-      lifecycle: job.lifecycle
-    })
-    return
-  }
+  if (Array.isArray(nodes) && nodes.length > 0) {
+    for (let nodeW of nodes) {
+      const edgeLabel = graph.edge(nodeV, nodeW)
+      if (edgeLabel === event.name) {
+        const jobPromise = Task
+          .findById(nodeW)
+          .then(async (task) => {
+            if (!task) {
+              throw new Error(`workflow step ${nodeW} is missing`)
+            }
 
-  const promises = []
-  for (let nodeW of nodes) {
-    const edgeLabel = graph.edge(nodeV, nodeW)
-    if (edgeLabel === event.name) {
-      promises.push(
-        Task.findById(nodeW)
-        .then(async (task) => {
-          if (!task) {
-            throw new Error(`workflow step ${nodeW} is missing`)
-          }
-
-          const { user, dynamic_settings } = await ifTriggeredByJobSettings(job)
-          const createPromise = createJob({
-            order: workflow_job.order,
-            user,
-            task,
-            task_arguments_values: argsValues,
-            dynamic_settings,
-            workflow,
-            workflow_job_id: workflow_job._id,
-            origin: JobConstants.ORIGIN_WORKFLOW
+            const { user, dynamic_settings } = await ifTriggeredByJobSettings(job)
+            return createTaskJob({
+              order: workflow_job.order,
+              user,
+              task,
+              task_arguments_values: argsValues,
+              dynamic_settings,
+              workflow,
+              workflow_job_id: workflow_job._id,
+              origin: JobConstants.ORIGIN_WORKFLOW
+            })
           })
+          .then(job => {
+            if (isNaN(workflow_job.active_jobs_counter)) {
+              // not a number. cannot be updated. older jobs, error..
+              return null
+            }
 
-          createPromise.catch(err => { return err })
-          return createPromise
-        })
-      )
+            // increase
+            workflow_job.active_jobs_counter += 1
+            return App.Models.Job.Workflow.updateOne(
+              { _id: workflow_job._id },
+              { $inc: { active_jobs_counter: 1 } }
+            )
+          }).catch(err => { return err })
+
+        promises.push(jobPromise)
+      }
     }
   }
 
-  return Promise.all(promises)
+  await Promise.all(promises)
+
+  if (workflow_job.active_jobs_counter === 0) {
+    //
+    // WARNING: this counter is neccesary to evaluate simultaneous && paralell jobs. a better solution is required (a specific task to control parallel executed jobs)
+    // 
+    // if counter doesn't reach cero, the finished event won't trigger
+    App.jobDispatcher.finishWorkflowJob(workflow_job, {
+      trigger_name: job.trigger_name,
+      state: job.state,
+      lifecycle: job.lifecycle
+    })
+  }
 }
 
 /**

--- a/core/service/job/factory.js
+++ b/core/service/job/factory.js
@@ -53,7 +53,7 @@ const JobsFactory = {
    * @param {Object} input
    * @return {Promise}
    */
-  createWorkflow (input) {
+  createWorkflowJob (input) {
     const builder = new WorkflowJob(input)
     return builder.create()
   },

--- a/core/service/job/factory.js
+++ b/core/service/job/factory.js
@@ -316,7 +316,11 @@ class WorkflowJob {
     const { workflow, user, customer } = input
 
     const wJob = new JobModels.Workflow(
-      Object.assign({},
+      Object.assign(
+        {
+          state: StateConstants.IN_PROGRESS,
+          //lifecycle: LifecycleConstants.READY
+        },
         input, /* VARIABLE parameters, depends on the CONTEXT */
         {
           /* FIXED parameters */

--- a/core/service/job/index.js
+++ b/core/service/job/index.js
@@ -435,6 +435,10 @@ module.exports = {
   async jobInputsReplenish (input) {
     const { job, user } = input
 
+    if (job.workflow_job) {
+      await App.Models.Job.Workflow.incActiveJobs(job.workflow_job_id, 1)
+    }
+
     if (
       job._type !== JobConstants.SCRIPT_TYPE &&
       job._type !== JobConstants.NODEJS_TYPE
@@ -499,7 +503,7 @@ module.exports = {
       // only available when the workflow is started
       if (workflow_job) {
         workflow_job.active_jobs_counter = 1
-        await workflow_job.save()
+        await App.Models.Job.Workflow.incActiveJobs(workflow_job._id, 1)
       }
 
       if (workflow.autoremove_completed_jobs !== false) {

--- a/core/service/job/index.js
+++ b/core/service/job/index.js
@@ -821,26 +821,6 @@ const populateWorkflow = async (job) => {
 const createJob = async (input) => {
   const { task, user } = input
 
-  //const job = await new Promise((resolve, reject) => {
-  //  JobFactory.create(task, input, async (err, job) => {
-  //    if (err) { return reject(err) }
-
-  //    if (!job) {
-  //      const err = new Error('Job was not created')
-  //      return reject(err)
-  //    }
-
-  //    if (job.constructor.name !== 'model') {
-  //      const err = new Error('Invalid job returned')
-  //      err.job = job
-  //      return reject(err)
-  //    }
-
-  //    logger.log('job created.')
-  //    resolve(job)
-  //  })
-  //})
-  //
   const job = await JobFactory.create(task, input)
 
   if (!job) {
@@ -855,7 +835,7 @@ const createJob = async (input) => {
 
   logger.log('job created.')
 
-  // await notification and system log generation
+  // await notification and logs generation
   await RegisterOperation.submit(Constants.CREATE, TopicsConstants.job.crud, { job, user })
 
   if (task.type === TaskConstants.TYPE_DUMMY) {

--- a/local.sh
+++ b/local.sh
@@ -9,5 +9,5 @@ fi
 
 export MONITORING_DISABLED=""
 export SCHEDULER_JOBS_DISABLED=""
-npx nodemon ${1} $PWD/core/main.js
+npx nodemon --inspect ${1} $PWD/core/main.js
 #node ${1} $PWD/core/main.js


### PR DESCRIPTION
 Feat: Better handling of workflow events.

1. A new property was added to workflow-job model to contabilice and control the active jobs during the workflow-job lifespan.

prop: active_jobs_counter, type: Number, default: undefined.

It is undefined by default to prevent workflows to crash, after the deploy.
When a task-job is started or finished the active_jobs_counter counter increases or decreases.

2. Whenever a job finishes it triggers the job.finished event to the events dispatchers. The same event is handled by task and workflow event handlers accordingly. 

3. When a workflow reaches the end (the last node in a path and there are no more nodes to execute) the workflow.job.finished event is triggered. This feature is currently under development and is not yet functional. It is a work in progress and does not have any implemented functionality at this time.