### PR TITLE
fix: jobs restart and inputs replenish

### DIFF
--- a/core/controllers/job/lifecycle.js
+++ b/core/controllers/job/lifecycle.js
@@ -284,7 +284,10 @@ const controller = {
       if (job._type === JobConstants.DUMMY_TYPE) {
         await submitDummyInputs(req)
       }
-      else if (job._type === JobConstants.SCRIPT_TYPE) {
+      else if (
+        job._type === JobConstants.SCRIPT_TYPE ||
+        job._type === JobConstants.NODEJS_TYPE
+      ) {
         await submitJobInputs(req)
       }
       res.send(200, job)

--- a/core/service/job/index.js
+++ b/core/service/job/index.js
@@ -420,12 +420,16 @@ module.exports = {
   /**
    * @return {Promise<Job>}
    */
-  restart (input) {
+  async restart (input) {
     const { job } = input
 
     job.trigger_name = null
     job.result = {}
     job.output = {}
+
+    if (job.workflow_job) {
+      await App.Models.Job.Workflow.incActiveJobs(job.workflow_job_id, 1)
+    }
 
     return this.jobInputsReplenish(input)
   },
@@ -434,17 +438,6 @@ module.exports = {
    */
   async jobInputsReplenish (input) {
     const { job, user } = input
-
-    if (job.workflow_job) {
-      await App.Models.Job.Workflow.incActiveJobs(job.workflow_job_id, 1)
-    }
-
-    if (
-      job._type !== JobConstants.SCRIPT_TYPE &&
-      job._type !== JobConstants.NODEJS_TYPE
-    ) {
-      throw new Error('only script tasks allowed')
-    }
 
     await JobFactory.restart(input)
 


### PR DESCRIPTION
restarting a job must increase the workflow-job active jobs counter. but giving input to a job being executing must not increase workflow-job active jobs.

