### PR TITLE
refactor: remove acl dynamic

### DIFF
--- a/core/app/api.js
+++ b/core/app/api.js
@@ -86,7 +86,7 @@ module.exports = function () {
 
   server.on('uncaughtException', (req, res, route, error) => {
     const handler = new ErrorHandler()
-    handler.sendExceptionAlert(error)
+    handler.sendExceptionAlert(error, req)
     logger.error('Message Error: %s', error.message)
     logger.error('Stack %s', error.stack)
     res.send(500, 'internal error')

--- a/core/constants/task.js
+++ b/core/constants/task.js
@@ -22,6 +22,7 @@ exports.ARGUMENT_TYPE_REMOTE_OPTIONS = ARGUMENT_TYPE_REMOTE_OPTIONS
 
 exports.APPROVALS_TARGET_FIXED = 'fixed'
 exports.APPROVALS_TARGET_ASSIGNEES = 'assignees'
+exports.APPROVALS_TARGET_DYNAMIC = 'dynamic'
 exports.APPROVALS_TARGET_INITIATOR = 'initiator'
 
 exports.ARGUMENT_TYPES = Object.freeze([

--- a/core/constants/topics.js
+++ b/core/constants/topics.js
@@ -1,19 +1,21 @@
-exports.monitor = {
+const Monitor = exports.monitor = {
   crud: 'monitor-crud',
   execution: 'monitor-execution',
   state: 'monitor-state'
 }
-exports.indicator = {
+
+const Indicator = exports.indicator = {
   crud: 'indicator-crud',
   state: 'indicator-state'
 }
+
 exports.script = {
   crud: 'script-crud'
 }
 exports.agent = {
   version: 'agent-version'
 }
-exports.file = {
+const File = exports.file = {
   crud: 'file-crud'
 }
 exports.hostgroup = {
@@ -42,7 +44,7 @@ exports.task = {
   notification: 'notification-task'
 }
 
-exports.workflow = {
+const Workflow = exports.workflow = {
   //crud: 'workflow-crud',
   job: {
     crud: 'workflow-job-crud',
@@ -51,7 +53,7 @@ exports.workflow = {
   //execution: 'workflow-execution',
 }
 
-exports.job = {
+const Job = exports.job = {
   crud: 'job-crud',
   finished: 'job-finished'
 }
@@ -60,7 +62,17 @@ exports.schedule = {
   crud: 'schedule-crud'
 }
 
-exports.webhook = {
+const Webhook = exports.webhook = {
   crud: 'webhook-crud',
   triggered: 'webhook-triggered'
 }
+
+exports.triggers = [
+  Job.finished,
+  Webhook.triggered,
+  Workflow.job.finished,
+  File.crud,
+  Indicator.crud,
+  Indicator.state,
+  Monitor.state,
+]

--- a/core/controllers/event.js
+++ b/core/controllers/event.js
@@ -1,14 +1,68 @@
 
+const App = require('../app')
 const router = require('../router')
-const Event = require('../entity/event').Event
+const { ServerError, ClientError } = require('../lib/error-handler')
+
+const Types = [{
+  'name':'indicator',
+  'collection': App.Models.Indicator.Indicator,
+  'model': App.Models.Event.IndicatorEvent
+}, {
+  'name': 'task',
+  'collection': App.Models.Task.Task,
+  'model': App.Models.Event.TaskEvent
+}, {
+  'name': 'webhook',
+  'collection': App.Models.Webhook.Webhook,
+  'model': App.Models.Event.WebhookEvent
+}, {
+  'name': 'monitor',
+  'collection': App.Models.Monitor.Monitor,
+  'model': App.Models.Event.MonitorEvent
+//}, {
+//  'name': 'workflow',
+//  'collection': App.Models.Workflow.Workflow,
+//  'model': App.Models.Event.WorkflowEvent
+}]
 
 module.exports = (server) => {
 
-  server.get('/:customer/event',
+  const validateRequiredParamsMiddleware = async (req, res) => {
+    const body = req.body
+    const customer = req.customer
+
+    if (!body.type) {
+      throw new ClientError('emitter type is required')
+    }
+    if (!body.event_name) {
+      throw new ClientError('event name is required')
+    }
+    if (!body.emitter_id) {
+      throw new ClientError('emitter id is required')
+    }
+
+    const typeModel = Types.find(t => t.name === body.type)
+    if (!typeModel) {
+      throw new ClientError(`Type ${type} is not implemented`)
+    }
+  }
+
+  server.post('/event',
     server.auth.bearerMiddleware,
-    router.resolve.customerNameToEntity({ required: true }),
+    router.requireCredential('admin'),
+    router.resolve.customerSessionToEntity(),
     router.ensureCustomer,
-    controller.fetch
+    validateRequiredParamsMiddleware,
+    controller.create
+  )
+
+  server.post('/event/ensure',
+    server.auth.bearerMiddleware,
+    router.requireCredential('admin'),
+    router.resolve.customerSessionToEntity(),
+    router.ensureCustomer,
+    validateRequiredParamsMiddleware,
+    controller.ensureExists
   )
 
   server.get('/:customer/event/:event',
@@ -19,22 +73,197 @@ module.exports = (server) => {
     controller.get
   )
 
+  server.get('/:customer/event',
+    server.auth.bearerMiddleware,
+    router.resolve.customerSessionToEntity(),
+    router.ensureCustomer,
+    router.ensurePermissions(),
+    router.dbFilter(),
+    controller.fetch
+  )
+
+  server.get('/event',
+    server.auth.bearerMiddleware,
+    router.resolve.customerSessionToEntity(),
+    router.ensureCustomer,
+    router.ensurePermissions(),
+    router.dbFilter(),
+    controller.fetch
+  )
+
+  server.get('/event/emitters', 
+    server.auth.bearerMiddleware,
+    router.requireCredential('admin'),
+    router.resolve.customerSessionToEntity(),
+    router.ensureCustomer,
+    router.ensurePermissions(),
+    router.dbFilter(),
+    controller.fetchEmitters
+  )
+
+  server.get('/event/type/:type/emitter/:emitter/events',
+    server.auth.bearerMiddleware,
+    router.requireCredential('admin'),
+    router.resolve.customerSessionToEntity(),
+    router.ensureCustomer,
+    router.ensurePermissions(),
+    router.dbFilter(),
+    controller.getEmitterEvents
+  )
 }
 
 const controller = {
-  fetch (req, res, next) {
-    Event.fetch({
-      customer: req.customer._id,
-      emitter: { $ne: null }
-    }, (err,events) => {
-      if (err) {
-        res.sendError(err)
-      } else {
-        res.send(200, events)
+  async ensureExists (req, res) {
+    try {
+      const { type } = req.body
+      const typeModel = Types.find(t => t.name === type)
+      const eventData = prepareEventData(req)
+      let event = await typeModel.model.findOne({
+        name: eventData.name,
+        emitter: eventData.emitter_id,
+        customer: eventData.customer,
+      })
+      if (!event) {
+        event = await typeModel.model.create(eventData)
       }
-    })
+
+      await event.populate({
+        path: 'emitter',
+        select: '_id name title _type type host host_id workflow_id',
+        populate: {
+          path: 'host',
+          select: 'hostname _id'
+        }
+      }).execPopulate()
+      req.event = event
+      res.send(200, event)
+    } catch (err) {
+      res.sendError(err)
+    }
   },
-  get (req, res, next) {
+  async create (req, res) {
+    try {
+      const { type } = req.body
+      const typeModel = Types.find(t => t.name === type)
+      const eventData = prepareEventData(req)
+      let event = await typeModel.model.findOne({
+        name: eventData.name,
+        emitter: eventData.emitter_id,
+        customer: eventData.customer,
+      })
+      if (event) {
+        throw new ClientError('Event exists', {statusCode: 409})
+      }
+
+      event = await typeModel.model.create(eventData)
+      await event.populate({
+        path: 'emitter',
+        select: '_id name title _type type host host_id workflow_id',
+        populate: {
+          path: 'host',
+          select: 'hostname _id'
+        }
+      }).execPopulate()
+      req.event = event
+      res.send(200, event)
+    } catch (err) {
+      res.sendError(err)
+    }
+  },
+  async get (req, res) {
     req.send(200, req.event)
+  },
+  async fetch (req, res) {
+    const filters = req.dbQuery
+    filters.where.emitter = { $ne: null }
+    filters.include = '_id emitter name _type emitter_id'
+    filters.populate = {
+      path: 'emitter',
+      select: '_id name title _type type host host_id workflow_id',
+      populate: {
+        path: 'host',
+        select: 'hostname _id'
+      }
+    }
+
+    const events = await App.Models.Event.Event.fetchBy(filters)
+    res.send(200, events)
+  },
+  async fetchEmitters (req, res) {
+    try {
+      const filter = req.dbQuery
+
+      // to fetch Monitors
+      filter.where.$or.push({ customer_name: req.customer.name })
+
+      const qtype = req.query.type
+
+      filter.include = {
+        _id: 1,
+        name: 1,
+        title: 1,
+        _type: 1,
+        type: 1,
+        tags: 1
+      }
+
+      let payload = {}
+
+      let typeModel
+      if (qtype) {
+        typeModel = Types.find(t => t.name === qtype)
+        if (!typeModel) {
+          throw new ClientError(`Type ${qtype} is not implemented`)
+        }
+
+        payload[typeModel.name] = await typeModel.collection
+          .fetchBy(filter)
+      } else {
+        for (let index in Types) {
+          const type = Types[index]
+          payload[type.name] = await type.collection.fetchBy(filter)
+        }
+      }
+
+      res.send(200, payload)
+    } catch (err) {
+      res.sendError(err)
+    }
+  },
+  async getEmitterEvents (req, res) {
+    try {
+      const customer = req.customer
+      const filter = req.dbQuery
+      const { type, emitter } = req.params
+
+      const typeModel = Types.find(t => t.name === type)
+      if (!typeModel) {
+        throw new ClientError(`Type ${type} is not implemented`)
+      }
+
+      filter.where = {
+        customer: customer.id,
+        emitter: emitter
+      }
+
+      const events = await typeModel.model.fetchBy(filter)
+
+      res.send(200, events)
+    } catch (err) {
+      res.sendError(err)
+    }
   }
+}
+
+
+const prepareEventData = ({ body, customer }) => {
+  const eventData = {
+    name: body.event_name,
+    emitter: body.emitter_id,
+    emitter_id: body.emitter_id,
+    customer: customer.id,
+    customer_id: customer.id,
+  }
+
+  return eventData
 }

--- a/core/controllers/file.js
+++ b/core/controllers/file.js
@@ -177,7 +177,7 @@ const uploadFile = async (req, res) => {
   try {
     //const fileModel = (req.file || req.script)
     const fileModel = req.file
-    const fileUploaded = req.files.file
+    const fileUploaded = req.files?.file
     if (!fileUploaded) {
       throw new ClientError('file required')
     }
@@ -222,8 +222,11 @@ const updateFile = async (req, res) => {
   try {
     //const fileModel = (req.file || req.script)
     const fileModel = req.file
-    const fileUploaded = req.files.file
-    const params = req.params
+    const fileUploaded = req.files?.file
+    if (!fileUploaded) {
+      throw new ClientError('file required')
+    }
+    const params = req.params || {}
 
     let acl
     if (params.acl) {
@@ -308,11 +311,15 @@ const updateContentSchema = async (req, res) => {
 const createFile = async (req, res) => {
   try {
     const customer = req.customer
-    const file = req.files.file
-    const description = req.params.description
-    const isPublic = (req.params.public || false)
-    const mimetype = req.params.mimetype
-    const extension = req.params.extension
+    const file = req.files?.file
+    if (!fileUploaded) {
+      throw new ClientError('file required')
+    }
+    const params = req.params || {}
+    const description = params?.description
+    const isPublic = (params?.public || false)
+    const mimetype = params?.mimetype
+    const extension = params?.extension
 
     logger.log('creating file')
 

--- a/core/controllers/indicator/counter.js
+++ b/core/controllers/indicator/counter.js
@@ -4,6 +4,7 @@ const router = require('../../router')
 const logger = require('../../lib/logger')('eye:controller:indicator:counter')
 const TopicsConstants = require('../../constants/topics')
 const Constants = require('../../constants')
+const eventDispatcher = require('./events_middleware')
 
 module.exports = function (server) {
 
@@ -16,7 +17,7 @@ module.exports = function (server) {
     isNumericIndicator,
     controller.increase,
     audit.afterUpdate('indicator', { display: 'title' }),
-    notifyEvent({ operation: Constants.UPDATE })
+    eventDispatcher({ operation: Constants.UPDATE })
   )
 
   server.patch('/indicator/title/:title/increase',
@@ -28,7 +29,7 @@ module.exports = function (server) {
     isNumericIndicator,
     controller.increase,
     audit.afterUpdate('indicator', { display: 'title' }),
-    notifyEvent({ operation: Constants.UPDATE })
+    eventDispatcher({ operation: Constants.UPDATE })
   )
 
   server.patch('/indicator/:indicator/decrease',
@@ -40,7 +41,7 @@ module.exports = function (server) {
     isNumericIndicator,
     controller.decrease,
     audit.afterUpdate('indicator', { display: 'title' }),
-    notifyEvent({ operation: Constants.UPDATE })
+    eventDispatcher({ operation: Constants.UPDATE })
   )
 
   server.patch('/indicator/title/:title/decrease',
@@ -52,7 +53,7 @@ module.exports = function (server) {
     isNumericIndicator,
     controller.decrease,
     audit.afterUpdate('indicator', { display: 'title' }),
-    notifyEvent({ operation: Constants.UPDATE })
+    eventDispatcher({ operation: Constants.UPDATE })
   )
 
   server.patch('/indicator/:indicator/restart',
@@ -64,7 +65,7 @@ module.exports = function (server) {
     isNumericIndicator,
     controller.restart,
     audit.afterUpdate('indicator', { display: 'title' }),
-    notifyEvent({ operation: Constants.UPDATE })
+    eventDispatcher({ operation: Constants.UPDATE })
   )
 
   server.patch('/indicator/title/:title/restart',
@@ -76,7 +77,7 @@ module.exports = function (server) {
     isNumericIndicator,
     controller.restart,
     audit.afterUpdate('indicator', { display: 'title' }),
-    notifyEvent({ operation: Constants.UPDATE })
+    eventDispatcher({ operation: Constants.UPDATE })
   )
 }
 
@@ -135,28 +136,6 @@ const controller = {
       res.send(200)
       next()
     })
-  }
-}
-
-const notifyEvent = (options) => {
-  let operation = options.operation
-
-  return function (req, res, next) {
-    const indicator = req.indicator
-
-    App.notifications.generateSystemNotification({
-      topic: TopicsConstants.indicator.crud,
-      data: {
-        operation,
-        organization: req.customer.name,
-        organization_id: req.customer._id,
-        model_id: indicator._id,
-        model_type: indicator._type,
-        model: indicator
-      }
-    })
-
-    if (next) { return next() }
   }
 }
 

--- a/core/controllers/indicator/crud.js
+++ b/core/controllers/indicator/crud.js
@@ -30,6 +30,26 @@ module.exports = function (server) {
     controller.get
   )
 
+  // public indicator
+  server.get('/indicator/:indicator/secret/:secret',
+    router.resolve.idToEntity({ param: 'indicator', required: true }),
+    router.requireSecret('indicator'),
+    (req, res, next) => {
+      res.send(req.indicator)
+      next()
+    }
+  )
+
+  //server.get('/indicator/title/:title/secret/:secret',
+  //  router.resolve.idToEntity({ param: 'indicator', required: true }),
+  //  findByTitleMiddleware(),
+  //  router.requireSecret('indicator'),
+  //  (req, res, next) => {
+  //    res.send(req.indicator)
+  //    next()
+  //  }
+  //)
+
   server.get('/indicator/title/:title',
     server.auth.bearerMiddleware,
     router.resolve.customerSessionToEntity(),

--- a/core/controllers/indicator/events_middleware.js
+++ b/core/controllers/indicator/events_middleware.js
@@ -35,6 +35,7 @@ module.exports = (options) => {
     }
 
     let events = await App.Models.Event.IndicatorEvent.find({
+      enable: true,
       $or: [
         { emitter_id: indicator._id },
         { emitter_prop: 'tags', emitter_value: { $in: indicator.tags } },
@@ -43,8 +44,9 @@ module.exports = (options) => {
         { emitter_prop: 'name', emitter_value: indicator.name },
         { emitter_prop: 'title', emitter_value: indicator.title },
       ],
-      enable: true,
-      name: eventName
+      name: {
+        $in: [ eventName, 'ALL' ] // eventName: created, changed, deleted or "ALL"
+      }
     })
 
     if (!events || events.length === 0) {
@@ -70,8 +72,9 @@ module.exports = (options) => {
           operation,
           model_id: indicator._id,
           model_type: indicator._type,
-        }],
-        indicator
+        }, {
+          value: indicator.toObject()
+        }] // model
       })
     }
 

--- a/core/controllers/indicator/events_middleware.js
+++ b/core/controllers/indicator/events_middleware.js
@@ -1,0 +1,69 @@
+
+const App = require('../../app')
+
+const Constants = require('../../constants')
+
+const EventNamaByOperation = { }
+EventNamaByOperation[ Constants.CREATE ] = 'created'
+EventNamaByOperation[ Constants.REPLACE ] = 'changed'
+EventNamaByOperation[ Constants.UPDATE ] = 'changed'
+EventNamaByOperation[ Constants.DELETE ] = 'deleted'
+
+const TopicsConstants = require('../../constants/topics')
+
+module.exports = (options) => {
+  let { operation, eventName } = options
+
+  return async function (req, res) {
+    const topic = TopicsConstants.indicator.crud
+    const indicator = req.indicator
+
+    App.notifications.generateSystemNotification({
+      topic,
+      data: {
+        operation,
+        organization: req.customer.name,
+        organization_id: req.customer._id,
+        model_id: indicator._id,
+        model_type: indicator._type,
+        model: indicator
+      }
+    })
+
+    if (!eventName) {
+      eventName = EventNamaByOperation[operation]
+    }
+
+    let event = await App.Models.Event.IndicatorEvent.findOne({
+      emitter_id: indicator._id,
+      enable: true,
+      name: eventName
+    })
+
+    if (!event) {
+      event = await App.Models.Event.IndicatorEvent.create({
+        customer: req.customer._id,
+        emitter: indicator._id,
+        emitter_id: indicator._id,
+        name: eventName,
+        creation_date: new Date(),
+        last_update: new Date()
+      })
+    }
+
+    App.eventDispatcher.dispatch({
+      topic,
+      event,
+      data: [{
+        topic,
+        event_name: eventName,
+        operation,
+        model_id: indicator._id,
+        model_type: indicator._type,
+      }],
+      indicator
+    })
+
+    return
+  }
+}

--- a/core/controllers/job/crud.js
+++ b/core/controllers/job/crud.js
@@ -354,6 +354,10 @@ const controller = {
     try {
       const job = req.job
 
+      if (!job) {
+        throw new ClientError('job not found', {statusCode:404})
+      }
+
       let search = []
       search.push(job.user_id)
 

--- a/core/controllers/job/result.js
+++ b/core/controllers/job/result.js
@@ -1,6 +1,7 @@
 const App = require('../../app')
 const router = require('../../router')
 const logger = require('../../lib/logger')('controller:job')
+const { ClientError } = require('../../lib/error-handler')
 const AsyncMiddleware = require('../../lib/async-controller')
 const qs = require('qs')
 
@@ -126,6 +127,8 @@ const resultPolling = (req, res, next) => {
 const waitJobResult = async (req, job, customer, timeout, next) => {
 
   let isWaiting
+  let timerId
+  let channel
 
   if (!timeout || timeout > 60) {
     timeout = 60 // seconds. arbitrary
@@ -135,10 +138,12 @@ const waitJobResult = async (req, job, customer, timeout, next) => {
 
   timeout = (timeout * 1000)
 
-  let timerId
-  let channel
-
   const stopWaiting = async (err, message) => {
+    if (!isWaiting) {
+      logger.error('already stopped waiting. loop ended')
+      return
+    } 
+
     try {
       clearTimeout(timerId)
       App.redis.unsubscribe(channel)

--- a/core/entity/base-schema.js
+++ b/core/entity/base-schema.js
@@ -1,4 +1,3 @@
-'use strict'
 
 const util = require('util')
 const mongoose = require('mongoose')

--- a/core/entity/event/base-properties.js
+++ b/core/entity/event/base-properties.js
@@ -9,5 +9,7 @@ module.exports = {
   secret: { type: String, default: () => { return randomSecret() } },
   customer: { type: Schema.Types.ObjectId, ref: 'Customer' },
   customer_id: { type: Schema.Types.ObjectId },
-  emitter_id: { type: Schema.Types.ObjectId }
+  emitter_id: { type: Schema.Types.ObjectId },
+  emitter_prop: { type: String },
+  emitter_value: { type: String }
 }

--- a/core/entity/event/index.js
+++ b/core/entity/event/index.js
@@ -2,6 +2,7 @@
 const mongodb = require('../../lib/mongodb').db
 
 const BaseSchema = require('./schema')
+const IndicatorEventSchema = require('./indicator')
 const TaskEventSchema = require('./task')
 const MonitorEventSchema = require('./monitor')
 const WebhookEventSchema = require('./webhook')
@@ -10,13 +11,14 @@ const WorkflowEventSchema = require('./workflow')
 // default Event does not have a default Emitter
 const Event = mongodb.model('Event', new BaseSchema())
 const TaskEvent = Event.discriminator('TaskEvent', TaskEventSchema)
+const IndicatorEvent = Event.discriminator('IndicatorEvent', IndicatorEventSchema)
 const MonitorEvent = Event.discriminator('MonitorEvent', MonitorEventSchema)
 const WebhookEvent = Event.discriminator('WebhookEvent', WebhookEventSchema)
 const WorkflowEvent = Event.discriminator('WorkflowEvent', WorkflowEventSchema)
 
-Event.ensureIndexes()
 exports.Event = Event
 exports.TaskEvent = TaskEvent
 exports.MonitorEvent = MonitorEvent
 exports.WebhookEvent = WebhookEvent
 exports.WorkflowEvent = WorkflowEvent
+exports.IndicatorEvent = IndicatorEvent

--- a/core/entity/event/indicator.js
+++ b/core/entity/event/indicator.js
@@ -1,11 +1,9 @@
 const Schema = require('mongoose').Schema
 const BaseSchema = require('./schema')
 
-const EventSchema = new BaseSchema({
+const EventSchema = module.exports = new BaseSchema({
   emitter: {
     type: Schema.Types.ObjectId,
-    ref: 'Task'
-  },
+    ref: 'Indicator'
+  }
 })
-
-module.exports = EventSchema

--- a/core/entity/event/schema.js
+++ b/core/entity/event/schema.js
@@ -1,4 +1,3 @@
-
 const util = require('util')
 const properties = require('./base-properties')
 const BaseSchema = require('../base-schema')
@@ -12,6 +11,7 @@ function EventSchema (specs) {
   });
 
   this.statics.fetch = function (query,done) {
+    console.error('entity/event/schema.statics.fetch DEPRECATED!!!')
     this
       .find(query)
       .select('_id emitter name _type emitter_id')

--- a/core/entity/indicator/index.js
+++ b/core/entity/indicator/index.js
@@ -46,14 +46,6 @@ const CounterIndicator = Indicator.discriminator('CounterIndicator', CounterSche
 const ChartIndicator = Indicator.discriminator('ChartIndicator', ChartSchema)
 const FileIndicator = Indicator.discriminator('FileIndicator', FileSchema)
 
-Indicator.ensureIndexes()
-CounterIndicator.ensureIndexes()
-ProgressIndicator.ensureIndexes()
-TextIndicator.ensureIndexes()
-HTMLIndicator.ensureIndexes()
-ChartIndicator.ensureIndexes()
-FileIndicator.ensureIndexes()
-
 // called for both inserts and updates
 Indicator.on('afterSave', function (model) {
   model.last_update = new Date()

--- a/core/entity/indicator/schema.js
+++ b/core/entity/indicator/schema.js
@@ -1,7 +1,6 @@
 //const util = require('util')
 const Schema = require('mongoose').Schema
 const BaseSchema = require('../base-schema')
-const FetchBy = require('../../lib/fetch-by')
 const randomSecret = require('../../lib/random-secret')
 const Constants = require('../../constants/monitors')
 const ObjectId = Schema.Types.ObjectId
@@ -38,10 +37,6 @@ class IndicatorSchema extends BaseSchema {
     //  Object.assign({}, baseProps, specificProps),
     //  specs
     //)
-
-    this.statics.fetchBy = function (filter, next) {
-      FetchBy.call(this, filter, next)
-    }
 
     // Duplicate the ID field.
     this.virtual('id').get(function(){

--- a/core/entity/job/schema-properties.js
+++ b/core/entity/job/schema-properties.js
@@ -73,8 +73,6 @@ module.exports = {
   // will be only visible to the user/owner and the assigned_users.
   // if "true" acl will be empty on creation
   empty_viewers: { type: Boolean, default: false },
-  // @TODO REMOVE
-  acl_dynamic: { type: Boolean, default: false },
 
   // can be canceled by users
   cancellable: { type: Boolean, 'default': true },

--- a/core/entity/job/workflow.js
+++ b/core/entity/job/workflow.js
@@ -57,8 +57,6 @@ const props = {
   // will only be visible to assigned users.
   // if "true" job acl will be empty on creation
   empty_viewers: { type: Boolean, default: false }, // if "true" acl will be empty on creation
-  // @TODO REMOVE
-  acl_dynamic: { type: Boolean, default: false },
   active_paths_counter: { type: Number, default: undefined }
 }
 

--- a/core/entity/monitor/base.js
+++ b/core/entity/monitor/base.js
@@ -6,15 +6,15 @@ const logger = require('../../lib/logger')('eye:entity:monitor')
 /** Extended Schema. Includes non template attributes **/
 const MonitorSchema = new BaseSchema({
   order: { type: Number, default: 0 },
-  host_id: { type: String },
-  resource_id: { type: String, required: true },
-  template_id: { type: ObjectId },
   enable: { type: Boolean, default: true },
   creation_date: { type: Date, default: Date.now },
   last_update: { type: Date, default: Date.now },
-  template: { type: ObjectId, ref: 'MonitorTemplate' }, // has one
   host: { type: ObjectId, ref: 'Host' }, // belongs to
+  host_id: { type: String },
+  template: { type: ObjectId, ref: 'MonitorTemplate' }, // has one
+  template_id: { type: ObjectId },
   resource: { type: ObjectId, ref: 'Resource' }, // belongs to
+  resource_id: { type: String, required: true },
   env: { type: Object, default: () => { return {} } },
   _type: { type: String, 'default': 'ResourceMonitor' }
 }, { collection: 'resourcemonitors' })

--- a/core/entity/monitor/schema.js
+++ b/core/entity/monitor/schema.js
@@ -2,7 +2,7 @@ const util = require('util')
 const Schema = require('mongoose').Schema
 const ObjectId = Schema.Types.ObjectId
 const debug = require('debug')('eye:entity:monitor')
-const lodashAfter = require('lodash/after')
+const FetchBy = require('../../lib/fetch-by')
 
 const properties = {
   looptime: { type: Number },
@@ -62,6 +62,10 @@ function BaseSchema (specs, opts) {
 
     serial.source_model_id = this._id
     return serial
+  }
+
+  this.statics.fetchBy = function (filter, next) {
+    return FetchBy.call(this, filter, next)
   }
 
 }

--- a/core/entity/resource/schema.js
+++ b/core/entity/resource/schema.js
@@ -2,7 +2,7 @@ const util = require('util')
 const Schema = require('mongoose').Schema
 const Constants = require('../../constants/monitors')
 const FetchBy = require('../../lib/fetch-by')
-const lifecicle = require('mongoose-lifecycle')
+const lifecycle = require('mongoose-lifecycle')
 
 const properties = {
   order: { type: Number, default: 0 },
@@ -29,7 +29,7 @@ function BaseSchema (props, opts) {
 
   Schema.call(this, Object.assign({}, properties, props), specs)
 
-  this.plugin(lifecicle)
+  this.plugin(lifecycle)
 
   // Duplicate the ID field.
   this.virtual('id').get(function(){
@@ -50,7 +50,7 @@ function BaseSchema (props, opts) {
 
 
   this.statics.fetchBy = function (filter, next) {
-    FetchBy.call(this, filter, next)
+    return FetchBy.call(this, filter, next)
   }
 
   this.methods.publish = function (next) {

--- a/core/entity/webhook/index.js
+++ b/core/entity/webhook/index.js
@@ -1,17 +1,14 @@
-"use strict";
 
 const mongodb = require('../../lib/mongodb').db;
 const BaseSchema = require('./schema');
 const afterInsert = require('./afterInsert');
 const afterRemove = require('./afterRemove');
 
-var Webhook = mongodb.model('Webhook',
+const Webhook = mongodb.model('Webhook',
   new BaseSchema({
     _type: { type: String, 'default': 'Webhook' }
   })
 );
-
-Webhook.ensureIndexes();
 
 // called for both inserts and updates
 Webhook.on('afterSave', function(model) {

--- a/core/entity/webhook/schema.js
+++ b/core/entity/webhook/schema.js
@@ -1,54 +1,30 @@
-"use strict";
-
 const util = require('util');
-const Schema = require('mongoose').Schema;
-const lifecicle = require('mongoose-lifecycle');
+const ObjectId = require('mongoose').Schema.Types.ObjectId
+const BaseSchema = require('../base-schema')
 const randomSecret = require('../../lib/random-secret');
 
-function BaseSchema (specs) {
-  // Schema constructor
-  Schema.call(
-    this,
-    Object.assign({
-      name: { type: String, required:true },
-      creation_date: { type: Date, default: Date.now },
-      last_update: { type: Date, default: null },
-      enable: { type: Boolean, default: true },
-      customer_id: { type: Schema.Types.ObjectId },
-      customer: { type: Schema.Types.ObjectId, ref: 'Customer' },
-      trigger_count: { type: Number, default: 0 },
-      // one way hash
-      secret: { type: String, 'default': randomSecret }
-    }, specs), {
-      collection: 'webhooks',
-      discriminatorKey: '_type'
-    }
-  )
-
-  // Duplicate the ID field.
-  this.virtual('id').get(function(){
-    return this._id.toHexString();
-  });
-
-  const def = {
-    getters: true,
-    virtuals: true,
-    transform: function (doc, ret, options) {
-      // remove the _id of every document before returning the result
-      ret.id = ret._id;
-      delete ret._id;
-      delete ret.__v;
-    }
+function WebhookSchema (specs) {
+  const props = {
+    name: { type: String, required:true },
+    creation_date: { type: Date, default: Date.now },
+    last_update: { type: Date, default: null },
+    enable: { type: Boolean, default: true },
+    customer_id: { type: ObjectId },
+    customer: { type: ObjectId, ref: 'Customer' },
+    trigger_count: { type: Number, default: 0 },
+    // one way hash
+    secret: { type: String, 'default': randomSecret }
   }
 
-  this.set('toJSON'  , def);
-  this.set('toObject', def);
-
-  this.plugin(lifecicle);
+  // Schema constructor
+  BaseSchema.call(this, Object.assign({}, props, specs), {
+    collection: 'webhooks',
+    discriminatorKey: '_type'
+  })
 
   return this;
 }
 
-util.inherits(BaseSchema, Schema);
+util.inherits(WebhookSchema, BaseSchema);
 
-module.exports = BaseSchema;
+module.exports = WebhookSchema;

--- a/core/entity/workflow/schema.js
+++ b/core/entity/workflow/schema.js
@@ -50,9 +50,6 @@ function WorkflowSchema (props) {
     // jobs behaviour can change during run time
     allows_dynamic_settings: { type: Boolean },
 
-    // @TODO REMOVE
-    acl_dynamic: { type: Boolean, default: false },
-
     // default schema type
     _type: {
       type: String,

--- a/core/lib/auth/index.js
+++ b/core/lib/auth/index.js
@@ -42,7 +42,7 @@ module.exports = {
         //
         // WARNING!! Integration Tokens cannot be verified using JWT.verify
         //
-        // 2023/09/06. Most of the Integration tokens were created with equal expiration and issue date.
+        // 2023/09/06. Most of the Integration tokens were created with invalid expiration and issue date.
         // Tokens can be verified against the information stored in the sessions db by the Gateway API but cannot be verifies using JWT methods.
         //
         logger.log('new connection [bearer]')

--- a/core/lib/storage.js
+++ b/core/lib/storage.js
@@ -144,9 +144,10 @@ const LocalStorage = {
   },
   getStream (key, customerName, next) {
     const storagePath = systemConfig.file_upload_folder
-    const filepath = path.join(storagePath, customerName, 'scripts', key)
+    let filepath
 
     try {
+      filepath = path.join(storagePath, customerName, 'scripts', key)
       fs.accessSync(filepath, fs.R_OK)
     } catch (err) {
       // file is not found in the storage

--- a/core/router/db-filter.js
+++ b/core/router/db-filter.js
@@ -1,3 +1,4 @@
+//const logger = require('../lib/logger')('router:db-filter')
 const dbFilter = require('../lib/db-filter')
 const { ForbiddenError, ServerError } = require('../lib/error-handler')
 const EscapedRegExp = require('../lib/escaped-regexp')
@@ -8,19 +9,28 @@ module.exports = function (options) {
       const customer = req.customer
       const query = req.query
       const filter = dbFilter(query)
-      filter.where.customer_id = customer.id
+      filter.where.$or = [
+        { customer_id: customer.id },
+        { customer: customer.id }
+      ]
 
-      if (!req.permissions) {
-        throw new ForbiddenError()
+      if (!req.hasOwnProperty('permissions')) {
+        const reqp = req._url?.pathname
+        const msg =`Missing ensure-permissions middleware before fetch invocation in req path: ${reqp}`
+        throw new ServerError(msg)
       }
 
       if (req.permissions !== true) {
         if (!Array.isArray(req.permissions)) {
           throw new ServerError('Bad permissions definition')
         }
-        const acl = req.permissions.map(p => {
-          return new EscapedRegExp(`${p.value}`,'i')
-        })
+
+        if (!req.permissions.length === 0) {
+          throw new ForbiddenError()
+        }
+
+        const acl = req.permissions
+          .map(p => new EscapedRegExp(`${p.value}`,'i'))
         filter.where.acl = { $in: acl }
       }
 

--- a/core/service/events/dispatcher.js
+++ b/core/service/events/dispatcher.js
@@ -4,22 +4,26 @@ const logger = require('../../lib/logger')(':events:dispatcher')
 const _prefix = 'ID_'
 const _callbacks = []
 
-var _lastID = 1
+let _lastID = 1
 
 class Dispatcher extends EventEmitter {
 
-	dispatch (payload) {
-    logger.log('dispatching event %o', payload)
-		for (var idx in _callbacks) {
-      _callbacks[idx](payload)
-		}
-	}
+  dispatch (payload) {
+    if (!Array.isArray(payload.data)) {
+      logger.error(`WARNING! array expected but ${typeof payload.data} was received instead`)
+    }
 
-	register (callback) {
-		var id = _prefix + _lastID++
-		_callbacks[id] = callback
-		return id
-	}
+    logger.log('dispatching event %o', payload)
+    for (let idx in _callbacks) {
+      _callbacks[idx](payload)
+    }
+  }
+
+  register (callback) {
+    const id = _prefix + _lastID++
+    _callbacks[id] = callback
+    return id
+  }
 
 }
 

--- a/core/service/events/task-trigger-by.js
+++ b/core/service/events/task-trigger-by.js
@@ -40,7 +40,9 @@ module.exports = async function (payload) {
  * @param {Mixed} data event data, this is the job.output
  * @param {Job} job the job that generates the event
  */
-const triggeredByEvent = async ({ event, data, job }) => {
+const triggeredByEvent = async (payload) => {
+
+  const { event, data, job } = payload
 
   if (!event||!event._id) {
     return

--- a/core/service/events/task-trigger-by.js
+++ b/core/service/events/task-trigger-by.js
@@ -20,6 +20,10 @@ module.exports = async function (payload) {
     // a task has completed its execution and triggered an event
     // or a monitor has changed its state
     if (
+      payload.topic === TopicConstants.file.crud ||
+      payload.topic === TopicConstants.indicator.crud ||
+      payload.topic === TopicConstants.indicator.state ||
+      payload.topic === TopicConstants.workflow.job.finished ||
       payload.topic === TopicConstants.monitor.state ||
       payload.topic === TopicConstants.webhook.triggered ||
       payload.topic === TopicConstants.job.finished

--- a/core/service/events/workflow.js
+++ b/core/service/events/workflow.js
@@ -29,8 +29,12 @@ module.exports = async function (payload) {
       handleWorkflowTaskJobFinishedEvent(payload)
     }
 
-    // case 2. a job has finished and the execution of another workflow must be started
+    // case 2. somthing happened and the execution of a workflow must be started
     if (
+      payload.topic === TopicConstants.file.crud ||
+      payload.topic === TopicConstants.indicator.crud ||
+      payload.topic === TopicConstants.indicator.state ||
+      payload.topic === TopicConstants.workflow.job.finished ||
       payload.topic === TopicConstants.monitor.state ||
       payload.topic === TopicConstants.webhook.triggered ||
       payload.topic === TopicConstants.job.finished

--- a/core/service/events/workflow.js
+++ b/core/service/events/workflow.js
@@ -236,6 +236,7 @@ const createWorkflowNodeJob = async ({ workflow, job, nodeW, workflow_job, argsV
 
   const { user, dynamic_settings } = await ifTriggeredByJobSettings(job)
   const nodeJob = await createTaskJob({
+    workflow_job,
     workflow_job_id: workflow_job._id,
     order: workflow_job.order,
     user,

--- a/core/service/job/factory.js
+++ b/core/service/job/factory.js
@@ -675,6 +675,8 @@ class ApprovalJob extends AbstractJob {
       job.approvers = [ job.user_id ]
     } else if (job.approvals_target === TaskConstants.APPROVALS_TARGET_ASSIGNEES) {
       job.approvers = job.assigned_users
+    } else if (job.approvals_target === TaskConstants.APPROVALS_TARGET_DYNAMIC) {
+      job.approvers = []
     } else if (!job.approvals_target || job.approvals_target === TaskConstants.APPROVALS_TARGET_FIXED) {
       job.approvers = task.approvers
     }
@@ -714,7 +716,7 @@ class ApprovalJob extends AbstractJob {
               }
 
               job['approvers'] = users.map(u => u.id)
-              job.approvals_target = TaskConstants.APPROVALS_TARGET_ASSIGNEES
+              job.approvals_target = TaskConstants.APPROVALS_TARGET_FIXED
             } else {
               job[prop] = value
             }

--- a/core/service/job/factory.js
+++ b/core/service/job/factory.js
@@ -292,11 +292,8 @@ const updateAssignee = (job, members) => {
   job.user_inputs_members = members.map(mem => mem.id)
 }
 
-const ensureObserversAccess = ({ job, empty_viewers, acl, acl_dynamic = false }) => {
-  if (
-    empty_viewers === true ||
-    acl_dynamic === true // @TODO remove
-  ) {
+const ensureObserversAccess = ({ job, empty_viewers, acl }) => {
+  if (empty_viewers === true) {
     job.acl = []
   } else {
     job.acl = acl
@@ -341,8 +338,7 @@ class WorkflowJob {
     ensureObserversAccess({
       acl: workflow.acl,
       job: wJob,
-      empty_viewers: (input.empty_viewers || workflow.empty_viewers),
-      acl_dynamic: workflow.acl_dynamic
+      empty_viewers: (input.empty_viewers || workflow.empty_viewers)
     })
 
     //

--- a/core/service/job/index.js
+++ b/core/service/job/index.js
@@ -1201,7 +1201,16 @@ const dispatchJobCreatedEvent = async (job, input) => {
     })
 
     const topic = TopicsConstants.job.crud
-    App.eventDispatcher.dispatch({ topic, event, data: input, job })
+    // event data argument
+    const data = [{
+      topic,
+      //event_name: trigger_name,
+      operation: Constants.CREATE,
+      model_id: job._id.toString(),
+      model_type: job._type
+    }]
+
+    App.eventDispatcher.dispatch({ topic, event, data, job })
   } catch (err) {
     if (err) {
       return logger.error(err)
@@ -1222,7 +1231,7 @@ const dispatchFinishedWorkflowJobExecutionEvent = async (job) => {
     })
 
     const topic = TopicsConstants.workflow.job.finished
-    App.eventDispatcher.dispatch({ topic, event, data: {}, job })
+    App.eventDispatcher.dispatch({ topic, event, data: [], job })
   } catch (err) {
     if (err) {
       return logger.error(err)

--- a/core/service/job/payload-validation.js
+++ b/core/service/job/payload-validation.js
@@ -92,7 +92,7 @@ const paramsFilter = (req) => {
 const verifyUsers = async ({ users, customer, workflow, task }) => {
   if (!Array.isArray(users) || users.length === 0) { return }
 
-  // verify that every user is a member of the organization and has acl.
+  // verify that every user is a member of the organization and has access to the task and workflow.
   const members = await App.gateway.member.fromUsers(users, customer)
 
   // verify users are members of the organization

--- a/core/service/resource/index.js
+++ b/core/service/resource/index.js
@@ -132,7 +132,9 @@ function Service (resource) {
           }
         )
 
+        const topic = TopicsConstants.monitor.state
         const data = [{
+          topic,
           type: resource.type,
           monitor_id: resource._id.toString(),
           hostname: resource.hostname,
@@ -142,7 +144,7 @@ function Service (resource) {
         }]
 
         App.eventDispatcher.dispatch({
-          topic: TopicsConstants.monitor.state,
+          topic,
           event,
           resource,
           data

--- a/core/service/scheduler.js
+++ b/core/service/scheduler.js
@@ -408,33 +408,4 @@ const WorkflowJobProcessor = async (agendaJob) => {
   })
 }
 
-/**
- * @return {Array}
- */
-//const verifyTask = async (task, done) => {
-//  let customer = App.Models.Customer.Entity.findById(task.customer_id)
-//  let host = App.Models.Host.Entity.findById(task.host_id)
-//  let script
-//
-//  if (task.type === 'script') {
-//    script = App.Models.File.Script.findById(task.script_id)
-//  }
-//
-//  let data = await Promise.all([ customer, host, script ])
-//
-//  if (!data[0]) {
-//    throw new Error(`customer ${task.customer_id} is no longer available`)
-//  }
-//
-//  if (!data[1]) {
-//    throw new Error(`host ${task.host_id} is no longer available`)
-//  }
-//
-//  if (task.type === 'script' && ! data[2]) {
-//    throw new Error(`script ${task.script_id} is no longer available`)
-//  }
-//
-//  return data
-//}
-
 module.exports = new Scheduler()

--- a/local.sh
+++ b/local.sh
@@ -9,5 +9,5 @@ fi
 
 export MONITORING_DISABLED=""
 export SCHEDULER_JOBS_DISABLED=""
-npx nodemon --inspect ${1} $PWD/core/main.js
-#node ${1} $PWD/core/main.js
+#npx nodemon $PWD/core/main.js
+npx nodemon ${1} $PWD/core/main.js

--- a/local.sh
+++ b/local.sh
@@ -9,5 +9,5 @@ fi
 
 export MONITORING_DISABLED=""
 export SCHEDULER_JOBS_DISABLED=""
-#npx nodemon --inspect ${1} $PWD/core/main.js
-node ${1} $PWD/core/main.js
+npx nodemon --inspect ${1} $PWD/core/main.js
+#node ${1} $PWD/core/main.js


### PR DESCRIPTION
this property was used only once in a complex approval workflow.
the new way of doing this is using the "empty_viewers" property . this setting empty the acl of "viewers" before creating the job and hiding the execution to them.

neither the user interface nor the api supported it anymore. there is no way to set it but via DB.
we are no longer using this in new implementations.


before updating this code a migration data migration is needed.
